### PR TITLE
Data type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 .idea/
+.vscode
 # C extensions
 *.so
 

--- a/drf_payload_customizer/mixins/payload_transformation_mixin.py
+++ b/drf_payload_customizer/mixins/payload_transformation_mixin.py
@@ -1,5 +1,8 @@
+from collections import Mapping
 import re
 
+from rest_framework.settings import api_settings
+from rest_framework.serializers import ValidationError
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 
@@ -23,6 +26,13 @@ class PayloadTransformationMixin:
         return fields_dict
 
     def to_internal_value(self, camel_cased):
+        if not isinstance(camel_cased, Mapping):
+            message = self.error_messages['invalid'].format(
+                datatype=type(camel_cased).__name__
+            )
+            raise ValidationError({
+                api_settings.NON_FIELD_ERRORS_KEY: [message]
+            }, code='invalid')
         return super().to_internal_value(
             self.transform_to_internal_value(camel_cased)
         )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = open(path.join(PROJECT_DIR, 'README.md')).read()
 
 setup(
     name='drf-payload-customizer',
-    version='0.0.3',
+    version='0.0.4',
     packages=['drf_payload_customizer','drf_payload_customizer.mixins'],
     url='https://github.com/3YOURMIND/drf-payload-customizer',
     license='Apache License 2.0',


### PR DESCRIPTION
Lifting the data type checking from base serializer class. If `many=True` not specified and a list was pushed instead of an object, it tried accessing `.items()` and an error was raised.